### PR TITLE
Add ignore parameter

### DIFF
--- a/check_rancher2.sh
+++ b/check_rancher2.sh
@@ -254,20 +254,24 @@ if [[ -z $clustername ]]; then
     for status in ${node_status[$i]}
     do 
       if [[ ${status} != active ]]; then 
-        if [[ -n $(echo ${ignore} | grep -i ${status}) ]]; then break
-        else nodeerrors[$i]="${node} in cluster ${node_cluster_member[$i]} is ${node_status[$i]} -"
+        if [[ -n $(echo ${ignore} | grep -i ${status}) ]]; then
+          nodeignored[$i]="${node} in cluster ${node_cluster_member[$i]} is ${node_status[$i]} but ignored -"
+        else
+          nodeerrors[$i]="${node} in cluster ${node_cluster_member[$i]} is ${node_status[$i]} -"
         fi
       fi
     done
   let i++
   done
 
-  if [[ ${#nodeerrors[*]} -gt 0 ]]
-  then 
-    echo "CHECK_RANCHER2 CRITICAL - ${nodeerrors[*]}|'nodes_total'=${#node_names[*]};;;; 'node_errors'=${#nodeerrors[*]};;;;"
+  if [[ ${#nodeerrors[*]} -gt 0 ]]; then
+    echo "CHECK_RANCHER2 CRITICAL - ${nodeerrors[*]}|'nodes_total'=${#node_names[*]};;;; 'node_errors'=${#nodeerrors[*]};;;; 'node_ignored'=${#nodeignored[*]};;;;"
     exit ${STATE_CRITICAL}
+  elif [[ ${#nodeignored[*]} -gt 0 ]]; then
+    echo "CHECK_RANCHER2 OK - All nodes OK - Info: ${nodeignored[*]}|'nodes_total'=${#node_names[*]};;;; 'node_errors'=${#nodeerrors[*]};;;; 'node_ignored'=${#nodeignored[*]};;;;"
+    exit ${STATE_OK}
   else
-    echo "CHECK_RANCHER2 OK - All ${#node_names[*]} nodes are active|'nodes_total'=${#node_names[*]};;;; 'node_errors'=${#nodeerrors[*]};;;;"
+    echo "CHECK_RANCHER2 OK - All ${#node_names[*]} nodes are active|'nodes_total'=${#node_names[*]};;;; 'node_errors'=${#nodeerrors[*]};;;; 'node_ignored'=${#nodeignored[*]};;;;"
     exit ${STATE_OK}
   fi
 
@@ -290,20 +294,24 @@ else
     for status in ${node_status[$i]}
     do 
       if [[ ${status} != active ]]; then 
-        if [[ -n $(echo ${ignore} | grep -i ${status}) ]]; then break
-        else nodeerrors[$i]="${node} in cluster ${clustername} is ${node_status[$i]} -"
+        if [[ -n $(echo ${ignore} | grep -i ${status}) ]]; then
+          nodeignored[$i]="${node} in cluster ${node_cluster_member[$i]} is ${node_status[$i]} but ignored -"
+        else
+          nodeerrors[$i]="${node} in cluster ${clustername} is ${node_status[$i]} -"
         fi
       fi
     done
   let i++
   done
 
-  if [[ ${#nodeerrors[*]} -gt 0 ]]
-  then 
-    echo "CHECK_RANCHER2 CRITICAL - ${nodeerrors[*]}|'nodes_total'=${#node_names[*]};;;; 'node_errors'=${#nodeerrors[*]};;;;"
+  if [[ ${#nodeerrors[*]} -gt 0 ]]; then
+    echo "CHECK_RANCHER2 CRITICAL - ${nodeerrors[*]}|'nodes_total'=${#node_names[*]};;;; 'node_errors'=${#nodeerrors[*]};;;; 'node_ignored'=${#nodeignored[*]};;;;"
     exit ${STATE_CRITICAL}
+  elif [[ ${#nodeignored[*]} -gt 0 ]]; then
+    echo "CHECK_RANCHER2 OK - All nodes OK - Info: ${nodeignored[*]}|'nodes_total'=${#node_names[*]};;;; 'node_errors'=${#nodeerrors[*]};;;; 'node_ignored'=${#nodeignored[*]};;;;"
+    exit ${STATE_OK}
   else
-    echo "CHECK_RANCHER2 OK - All ${#node_names[*]} nodes are active|'nodes_total'=${#node_names[*]};;;; 'node_errors'=${#nodeerrors[*]};;;;"
+    echo "CHECK_RANCHER2 OK - All ${#node_names[*]} nodes are active|'nodes_total'=${#node_names[*]};;;; 'node_errors'=${#nodeerrors[*]};;;; 'node_ignored'=${#nodeignored[*]};;;;"
     exit ${STATE_OK}
   fi
 

--- a/icinga2/command_check_rancher2.conf
+++ b/icinga2/command_check_rancher2.conf
@@ -15,6 +15,7 @@ object CheckCommand "check_rancher2" {
     "-n" = "$rancher2_namespace$"
     "-w" = "$rancher2_workload$"
     "-o" = "$rancher2_pod$"
+    "-i" = "$rancher2_ignore_status$"
   }
 
   vars.rancher2_address = "$address$"

--- a/icinga2/example_service_checks.conf
+++ b/icinga2/example_service_checks.conf
@@ -42,6 +42,18 @@ object Service "Rancher2 Cluster Test" {
   vars.rancher2_cluster = "c-4kd22"
 }
 
+# Check nodes in all clusters for their status but ignore cordoned and drained nodes
+object Service "Rancher2 Nodes" {
+  import "generic-service"
+  host_name = "my-rancher2-host"
+  check_command = "check_rancher2"
+  vars.rancher2_username = "token-XXXXX"
+  vars.rancher2_password = "iWahca3ohngeiReedeingaiiWahca3ohngeiReedeingai432k1dda"
+  vars.rancher2_ssl = true
+  vars.rancher2_type = "node"
+  vars.rancher2_ignore_status = "cordoned,drained"
+}
+
 # Check all avaiable/found projects (across all clusters) for their health
 object Service "Rancher2 All Projects" {
   import "generic-service"


### PR DESCRIPTION
This PR adds a new parameter `"-i"` to manually set a list of status(es) to ignore.
Currently this only affects checks on nodes (using `-t node`). 

With this change, certain status(es) can be ignored, for example when a node is in cordoned or drained status.

