### PR TITLE
Make workload and pod checks namespace-aware

### DIFF
--- a/check_rancher2.sh
+++ b/check_rancher2.sh
@@ -489,6 +489,7 @@ if [[ -z $podname ]]; then
 # Check status of all pods within a project (project must be given)
   if [[ -n $namespacename && $namespacename != "" ]]; then
     nsappend="?namespaceId=$namespacename"
+    outputappend="and namespace $namespacename "
   fi
 
   api_out_pods=$(curl -s ${selfsigned} -u "${apiuser}:${apipass}" "${proto}://${apihost}/v3/project/${projectname}/pods${nsappend}")
@@ -523,7 +524,7 @@ if [[ -z $podname ]]; then
     echo "CHECK_RANCHER2 CRITICAL - ${poderrors[*]}|'pods_total'=${#pod_names[*]};;;; 'pods_errors'=${#poderrors[*]};;;;"
     exit ${STATE_CRITICAL}
   else
-    echo "CHECK_RANCHER2 OK - All pods (${#pod_names[*]}) in project ${projectname} are running|'pods_total'=${#pod_names[*]};;;; 'pods_errors'=${#poderrors[*]};;;;"
+    echo "CHECK_RANCHER2 OK - All pods (${#pod_names[*]}) in project ${projectname} ${outputappend}are running|'pods_total'=${#pod_names[*]};;;; 'pods_errors'=${#poderrors[*]};;;;"
     exit ${STATE_OK}
   fi
 

--- a/check_rancher2.sh
+++ b/check_rancher2.sh
@@ -39,7 +39,7 @@
 # 20200129 1.2.2 Fix typos in workload perfdata (#11) and single cluster health (#12)    #
 # 20200523 1.2.3 Handle 403 forbidden error (#15)                                        #
 # 20200617 1.3.0 Added ignore parameter (-i)                                             #
-# 20210203 1.4.0 Checking specific workloads and pods inside a namespace                 #
+# 20210210 1.4.0 Checking specific workloads and pods inside a namespace                 #
 ##########################################################################################
 # (Pre-)Define some fixed variables
 STATE_OK=0              # define the exit code if status is OK


### PR DESCRIPTION
This PR adds the possibility to check workloads within a specific namespace.
It also does the same for the pod check type.

Fixes #7 and #10 