### PR TITLE
Check for additional node (pressure) conditions

### DIFF
--- a/check_rancher2.sh
+++ b/check_rancher2.sh
@@ -45,7 +45,7 @@
 # 20210413 1.5.0 Plugin now uses jq instead of jshon, fix cluster error check (#19)      #
 # 20210504 1.6.0 Add usage performance data on single cluster check, fix project check   #
 # 20210824 1.6.1 Fix cluster and project not found error (#24)                           #
-# TBD 1.7.0 Check for additional node conditions (#27)                                   #
+# 20211021 1.7.0 Check for additional node (pressure) conditions (#27)                   #
 ##########################################################################################
 # (Pre-)Define some fixed variables
 STATE_OK=0              # define the exit code if status is OK


### PR DESCRIPTION
This PR adds additional internal checks to the `-t node` check. Before this PR, only the node status was checked. This could either be Active, Unavailable, Drained or Cordoned (if I remember correctly). This PR adds additional checks on pressure conditions, such as Disk Pressure. 